### PR TITLE
feat: hide drag using class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -211,7 +211,13 @@ function DragHandle(options: GlobalDragHandleOptions) {
             y: event.clientY,
           });
 
-          if (!(node instanceof Element) || node.matches('ul, ol')) {
+          const notDragging = node?.closest('.not-draggable');
+
+          if (
+            !(node instanceof Element) ||
+            node.matches('ul, ol') ||
+            notDragging
+          ) {
             hideDragHandle();
             return;
           }


### PR DESCRIPTION
Hides drag handle when a parent element has `.not-draggable` class.