### PR TITLE
Allows custom drag handles to be specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package-lock.json
 dist
+.idea

--- a/README.md
+++ b/README.md
@@ -36,13 +36,18 @@ import GlobalDragHandle from 'tiptap-extension-global-drag-handle'
 new Editor({
   extensions: [
     GlobalDragHandle.configure({
-        dragHandleWidth: 20,    // default
+        dragHandleWidth: 20, // default
 
         // The scrollTreshold specifies how close the user must drag an element to the edge of the lower/upper screen for automatic 
         // scrolling to take place. For example, scrollTreshold = 100 means that scrolling starts automatically when the user drags an 
         // element to a position that is max. 99px away from the edge of the screen
         // You can set this to 0 to prevent auto scrolling caused by this extension
-        scrollTreshold: 100     // default
+        scrollTreshold: 100, // default
+
+        // The css selector to query for the drag handle. (eg: '.custom-handle').
+        // If handle element is found, that element will be used as drag handle. 
+        // If not, a default handle will be created
+        dragHandleSelector: ".custom-drag-handle" // default is undefined
     }),
   ],
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tiptap-extension-global-drag-handle",
   "description": "drag handle extension for tiptap",
-  "version": "0.1.5",
+  "version": "0.1.8",
   "author": {
     "name": "Niclas Gregor",
     "email": "niclas.gregor20@gmail.com",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tiptap-extension-global-drag-handle",
   "description": "drag handle extension for tiptap",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": {
     "name": "Niclas Gregor",
     "email": "niclas.gregor20@gmail.com",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Extension } from '@tiptap/core';
-import { NodeSelection, Plugin, TextSelection } from '@tiptap/pm/state';
+import { NodeSelection, Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
 import { Fragment, Slice, Node } from '@tiptap/pm/model';
 
 // @ts-ignore
@@ -15,6 +15,11 @@ export interface GlobalDragHandleOptions {
    * The treshold for scrolling
    */
   scrollTreshold: number;
+
+  /*
+   * The css selector to query for the drag handle. (eg: '.custom-handle'). A handle will be created by default if this field is not set
+   */
+  dragHandleSelector?: string;
 }
 function absoluteRect(node: Element) {
   const data = node.getBoundingClientRect();
@@ -73,7 +78,7 @@ function calcNodePos(pos: number, view: EditorView) {
   return pos;
 }
 
-function DragHandle(options: GlobalDragHandleOptions) {
+export function DragHandlePlugin(options: GlobalDragHandleOptions & {pluginKey: string}) {
   let listType = '';
   function handleDragStart(event: DragEvent, view: EditorView) {
     view.focus();
@@ -169,16 +174,22 @@ function DragHandle(options: GlobalDragHandleOptions) {
   }
 
   return new Plugin({
+    key: new PluginKey(options.pluginKey),
     view: (view) => {
-      dragHandleElement = document.createElement('div');
+      const handleBySelector = options.dragHandleSelector ? document.querySelector<HTMLElement>(options.dragHandleSelector) : null
+      dragHandleElement = handleBySelector?? document.createElement('div');
       dragHandleElement.draggable = true;
       dragHandleElement.dataset.dragHandle = '';
       dragHandleElement.classList.add('drag-handle');
-      dragHandleElement.addEventListener('dragstart', (e) => {
-        handleDragStart(e, view);
-      });
 
-      dragHandleElement.addEventListener('drag', (e) => {
+
+      function onDragHandleDragStart(e: DragEvent) {
+        handleDragStart(e, view);
+      }
+
+      dragHandleElement.addEventListener('dragstart', onDragHandleDragStart);
+
+      function onDragHandleDrag(e: DragEvent) {
         hideDragHandle();
         let scrollY = window.scrollY;
         if (e.clientY < options.scrollTreshold) {
@@ -186,15 +197,23 @@ function DragHandle(options: GlobalDragHandleOptions) {
         } else if (window.innerHeight - e.clientY < options.scrollTreshold) {
           window.scrollTo({ top: scrollY + 30, behavior: 'smooth' });
         }
-      });
+      }
+
+      dragHandleElement.addEventListener('drag', onDragHandleDrag);
 
       hideDragHandle();
 
-      view?.dom?.parentElement?.appendChild(dragHandleElement);
+      if(!handleBySelector) {
+        view?.dom?.parentElement?.appendChild(dragHandleElement);
+      }
 
       return {
         destroy: () => {
-          dragHandleElement?.remove?.();
+          if(!handleBySelector) {
+            dragHandleElement?.remove?.();
+          }
+          dragHandleElement?.removeEventListener('drag', onDragHandleDrag);
+          dragHandleElement?.removeEventListener('dragstart', onDragHandleDragStart);
           dragHandleElement = null;
         },
       };
@@ -319,9 +338,11 @@ const GlobalDragHandle = Extension.create({
 
   addProseMirrorPlugins() {
     return [
-      DragHandle({
+      DragHandlePlugin({
+        pluginKey:'globalDragHandle',
         dragHandleWidth: this.options.dragHandleWidth,
         scrollTreshold: this.options.scrollTreshold,
+        dragHandleSelector: this.options.dragHandleSelector,
       }),
     ];
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,8 @@ export interface GlobalDragHandleOptions {
   scrollTreshold: number;
 
   /*
-   * The css selector to query for the drag handle. (eg: '.custom-handle'). A handle will be created by default if this field is not set
+   * The css selector to query for the drag handle. (eg: '.custom-handle').
+   * If handle element is found, that element will be used as drag handle. If not, a default handle will be created
    */
   dragHandleSelector?: string;
 }


### PR DESCRIPTION
https://github.com/NiclasDev63/tiptap-extension-global-drag-handle/issues/7

Added a new `dragHandleSelector` option.
When specified, instead of creating the drag handle, the plugin uses the element found when applying the query selector as the drag handle.