### PR TITLE
Line height returned 'normal' gets parsed to NaN

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -223,7 +223,10 @@ function DragHandle(options: GlobalDragHandleOptions) {
           }
 
           const compStyle = window.getComputedStyle(node);
-          const lineHeight = parseInt(compStyle.lineHeight, 10);
+          const parsedLineHeight = parseInt(compStyle.lineHeight, 10);
+          const lineHeight = isNaN(parsedLineHeight)
+            ? parseInt(compStyle.fontSize) * 1.2
+            : parsedLineHeight;
           const paddingTop = parseInt(compStyle.paddingTop, 10);
 
           const rect = absoluteRect(node);


### PR DESCRIPTION
When the computedStyle line height returns 'normal', it gets parsedInt to NaN causing the rect.top to also be NaN. This causes the drag handle to show at its last position the the correct left spacing but on the wrong line.

Instead proposing to use a fallback value being the fontSize * 1.2 (the average line height on most browsers). 

A more accurate way would be measuring an invisible element to calculate the line height but this seems a bit unnecessary since this situation seems pretty rare.