### PR TITLE
Support for Custom Nodes in Tiptap Drag-Handle Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ new Editor({
         // If you want to hide the global drag handle for specific HTML tags, you can use this option.
         // For example, setting this option to ['p', 'hr'] will hide the global drag handle for <p> and <hr> tags.
         excludedTags: [], // default
+
+        // Custom nodes to be included for drag handle
+        // For example having a custom Alert component. Add data-type="alert" to the node component wrapper.
+        // Then add it to this list as ['alert']
+        //
+        customNodes: [],
     }),
   ],
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,11 @@ export interface GlobalDragHandleOptions {
    * Tags to be excluded for drag handle
    */
   excludedTags: string[];
+
+  /**
+   * Custom nodes to be included for drag handle
+   */
+  customNodes: string[];
 }
 function absoluteRect(node: Element) {
   const data = node.getBoundingClientRect();
@@ -52,7 +57,10 @@ function absoluteRect(node: Element) {
   };
 }
 
-function nodeDOMAtCoords(coords: { x: number; y: number }) {
+function nodeDOMAtCoords(
+  coords: { x: number; y: number },
+  options: GlobalDragHandleOptions,
+) {
   return document
     .elementsFromPoint(coords.x, coords.y)
     .find(
@@ -65,6 +73,7 @@ function nodeDOMAtCoords(coords: { x: number; y: number }) {
             'pre',
             'blockquote',
             'h1, h2, h3, h4, h5, h6',
+            options.customNodes.map((node) => `[data-type=${node}]`),
           ].join(', '),
         ),
     );
@@ -98,10 +107,13 @@ export function DragHandlePlugin(
 
     if (!event.dataTransfer) return;
 
-    const node = nodeDOMAtCoords({
-      x: event.clientX + 50 + options.dragHandleWidth,
-      y: event.clientY,
-    });
+    const node = nodeDOMAtCoords(
+      {
+        x: event.clientX + 50 + options.dragHandleWidth,
+        y: event.clientY,
+      },
+      options,
+    );
 
     if (!(node instanceof Element)) return;
 
@@ -267,10 +279,13 @@ export function DragHandlePlugin(
             return;
           }
 
-          const node = nodeDOMAtCoords({
-            x: event.clientX + 50 + options.dragHandleWidth,
-            y: event.clientY,
-          });
+          const node = nodeDOMAtCoords(
+            {
+              x: event.clientX + 50 + options.dragHandleWidth,
+              y: event.clientY,
+            },
+            options,
+          );
 
           const notDragging = node?.closest('.not-draggable');
           const excludedTagList = options.excludedTags
@@ -371,6 +386,7 @@ const GlobalDragHandle = Extension.create({
       dragHandleWidth: 20,
       scrollTreshold: 100,
       excludedTags: [],
+      customNodes: [],
     };
   },
 
@@ -382,6 +398,7 @@ const GlobalDragHandle = Extension.create({
         scrollTreshold: this.options.scrollTreshold,
         dragHandleSelector: this.options.dragHandleSelector,
         excludedTags: this.options.excludedTags,
+        customNodes: this.options.customNodes,
       }),
     ];
   },


### PR DESCRIPTION
This PR adds support for [custom nodes](https://tiptap.dev/docs/editor/extensions/custom-extensions/node-views/javascript) in the Tiptap drag-handle extension using HTML `data-*` attributes. You can now pass a `data-type` attribute (e.g., `data-type="AlertNode"`) to nodes for enabling drag-and-drop functionality.

Key changes include:
- Ability to drag custom nodes (e.g., `AlertNode`) with the `data-type` attribute.

Example usage:

```vue
<!-- AlertComponent.vue -->
<template>
  <NodeViewWrapper data-type="AlertNode">
    <v-alert type="info" class="my-4" text>
      <node-view-content />
    </v-alert>
  </NodeViewWrapper>
</template>

<script lang="ts">
import { nodeViewProps, NodeViewWrapper, NodeViewContent } from '@tiptap/vue-2';

export default {
  components: {
    NodeViewWrapper,
    NodeViewContent,
  },
  props: nodeViewProps,
};
</script>
```

Drag-handle configuration:

```ts
GlobalDragHandle.configure({
  customNodes: [
    'AlertNode',
  ],
});
```