### PR TITLE
fix disappearence of drag handler when using custom dragHandleSelector class with multiple elements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -214,7 +214,8 @@ export function DragHandlePlugin(
       const relatedTarget = event.relatedTarget as HTMLElement;
       const isInsideEditor =
         relatedTarget?.classList.contains('tiptap') ||
-        relatedTarget?.classList.contains('drag-handle');
+        relatedTarget?.classList.contains('drag-handle') ||
+        dragHandleElement?.contains(relatedTarget);
 
       if (isInsideEditor) return;
     }


### PR DESCRIPTION
drag handler got hidden with usage of custom class selector.

drag handler element
```
<div class="custom-drag-handle">
  <button class="drag-handler-btn">Drag</button>
  <button class="add-action-btn">Add</button>
</div>
```

Editor config
```
new Editor({
  extensions: [
    GlobalDragHandle.configure({
        dragHandleSelector: ".custom-drag-handle", // default is undefined
    }),
  ],
})
```
