### PR TITLE
Fix: Update clipboard serialization due to __serializeForClipboard removal

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
 import { Fragment, Slice, Node } from '@tiptap/pm/model';
 
 // @ts-ignore
-import { __serializeForClipboard, EditorView } from '@tiptap/pm/view';
+import { EditorView } from '@tiptap/pm/view';
 
 export interface GlobalDragHandleOptions {
   /**
@@ -182,7 +182,7 @@ export function DragHandlePlugin(
     }
 
     const slice = view.state.selection.content();
-    const { dom, text } = __serializeForClipboard(view, slice);
+    const { dom, text } = view.serializeForClipboard(slice)
 
     event.dataTransfer.clearData();
     event.dataTransfer.setData('text/html', dom.innerHTML);


### PR DESCRIPTION
This PR addresses the breaking change introduced in prosemirror-view ([commit 29f4053](https://github.com/ProseMirror/prosemirror-view/commit/29f4053d228b031d1b029c8e11998b52a96ea047)), where __serializeForClipboard was removed from exports.

Changes:
Removed direct usage of __serializeForClipboard.
Implemented an alternative approach for clipboard serialization.
Ensured compatibility with the latest version of prosemirror-view.