### PR TITLE
Fix: Prevent Import Error for __serializeForClipboard in some Bundlers 

### DIFF
--- a/src/clipboard-serializer.ts
+++ b/src/clipboard-serializer.ts
@@ -1,5 +1,15 @@
 import { Slice } from '@tiptap/pm/model';
 import { EditorView } from '@tiptap/pm/view';
+import * as pmView from '@tiptap/pm/view';
+
+function getPmView() {
+  try {
+      return pmView;
+  } catch (error) {
+      return null;
+  }
+}
+
 
 export function serializeForClipboard(view: EditorView, slice: Slice) {
   // Newer Tiptap/ProseMirror
@@ -9,11 +19,11 @@ export function serializeForClipboard(view: EditorView, slice: Slice) {
   }
 
   // Older version fallback
+  const proseMirrorView = getPmView();
   // @ts-ignore
-  const pmView = require('@tiptap/pm/view');
-  if (pmView && typeof pmView.__serializeForClipboard === 'function') {
+  if (proseMirrorView && typeof proseMirrorView?.__serializeForClipboard === 'function') {
     // @ts-ignore
-    return pmView.__serializeForClipboard(view, slice);
+    return proseMirrorView.__serializeForClipboard(view, slice);
   }
 
   throw new Error('No supported clipboard serialization method found.');

--- a/src/clipboard-serializer.ts
+++ b/src/clipboard-serializer.ts
@@ -1,17 +1,17 @@
-import * as pmView from '@tiptap/pm/view';
 import { Slice } from '@tiptap/pm/model';
+import { EditorView } from '@tiptap/pm/view';
 
-export function serializeForClipboard(view: pmView.EditorView, slice: Slice) {
+export function serializeForClipboard(view: EditorView, slice: Slice) {
   // Newer Tiptap/ProseMirror
   // @ts-ignore
-  if (typeof view.serializeForClipboard === 'function') {
-    // @ts-ignore
+  if (view && typeof view.serializeForClipboard === 'function') {
     return view.serializeForClipboard(slice);
   }
 
   // Older version fallback
   // @ts-ignore
-  if (typeof pmView.__serializeForClipboard === 'function') {
+  const pmView = require('@tiptap/pm/view');
+  if (pmView && typeof pmView.__serializeForClipboard === 'function') {
     // @ts-ignore
     return pmView.__serializeForClipboard(view, slice);
   }


### PR DESCRIPTION
While the code already included backward compatibility for __serializeForClipboard, certain bundlers like Webpack and Vite were throwing an import error:

`Attempted import error: '__serializeForClipboard' is not exported from '@tiptap/pm/view'.
`

Normally, accessing an undefined export should return undefined without breaking, but some bundlers manually throw an error when attempting to import a missing named export.