### PR TITLE
Feat: add onMouseMove callback to GlobalDragHandleOptions for node interaction tracking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,15 @@ export interface GlobalDragHandleOptions {
    * Custom nodes to be included for drag handle
    */
   customNodes: string[];
+
+  /**
+   * Callback function triggered on mouse move providing the current node in editor and its position.
+   *
+   * @param data - An object containing details about the node.
+   * @param data.node - The node that was interacted with.
+   * @param data.pos - The position/index of the node in the relevant structure.
+   */
+  onMouseMove?: (data: { node: Node; pos: number }) => void;
 }
 function absoluteRect(node: Element) {
   const data = node.getBoundingClientRect();
@@ -306,6 +315,19 @@ export function DragHandlePlugin(
             return;
           }
 
+          // Determine the position of the currently hovered node within the editor.
+          const nodePos = nodePosAtDOM(node, view, options);
+
+          if (nodePos !== undefined) {
+            // Retrieve the corresponding node from the editor's document state.
+            const currentNode = view.state.doc.nodeAt(nodePos);
+
+            if (currentNode !== null) {
+              // Invoke the callback function to notify about the node change.
+              options.onMouseMove?.({ node: currentNode, pos: nodePos });
+            }
+          }
+
           const compStyle = window.getComputedStyle(node);
           const parsedLineHeight = parseInt(compStyle.lineHeight, 10);
           const lineHeight = isNaN(parsedLineHeight)
@@ -404,6 +426,7 @@ const GlobalDragHandle = Extension.create({
         dragHandleSelector: this.options.dragHandleSelector,
         excludedTags: this.options.excludedTags,
         customNodes: this.options.customNodes,
+        onMouseMove: this.options.onMouseMove,
       }),
     ];
   },


### PR DESCRIPTION
## About the Feature
This introduces a callback function which allows user to have a track of currently hovered node in editor and its position. 

- This fixed the issue #36 
- Introduces the [`onNodeChange`](https://tiptap.dev/docs/editor/extensions/functionality/drag-handle#onnodechange) like functionality from [`@tiptap-pro/extension-drag-handle`](https://tiptap.dev/docs/editor/extensions/functionality/drag-handle)

## What's Possible
This feature allows users to implement more rich drag handle (notion like). Where one can perform certain actions as shown in video below. 

https://github.com/user-attachments/assets/38aec68f-f7dc-411a-84a9-778c8bef120c
